### PR TITLE
Docker publishing small syntax error on docker push

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ after_success:
   - if [ "$TRAVIS_BRANCH" == "master" ]; then docker login --username="$DOCKER_USER" --password="$DOCKER_PASS"; else echo "Foreign pullrequest/branch, not pushing to DockerHub" ; fi 
   - if [ "$TRAVIS_BRANCH" == "master" ]; then docker build -f Dockerfile -t $REPO:$COMMIT . ; fi
   - if [ "$TRAVIS_BRANCH" == "master" ]; then docker tag $REPO:$COMMIT $REPO:$TAG ; fi
-  - if [ "$TRAVIS_BRANCH" == "master" ]; docker push $REPO ; fi
+  - if [ "$TRAVIS_BRANCH" == "master" ]; then docker push $REPO ; fi
 
 branches:
   - master


### PR DESCRIPTION
Accidentally forgot a `then` in the `.travis.yml` file. After this, new cgtd docker images should be published without issues on the docker hub *and* no failed builds for non-master pullrequests.

See: https://travis-ci.org/ga4gh/cgtd/builds/176078291#L520